### PR TITLE
Removes Nuxt from GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add yours via a pull request!
 - NASA (Vue / Nuxt)
 - Shopify (React + Vite)
 - Cloudflare (Astro, Qwik)
-- GitLab (Vue / Nuxt)
+- GitLab (Vue)
 - Porsche (Astro)
 - The Guardian (Astro)
 - New York Times (Svelte / SvelteKit)


### PR DESCRIPTION
GitLab does use Nuxt in some cases (like our design system repo) but the GitLab product does not.