### PR TITLE
Add Stormkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Add yours via a pull request!
 - Hugging Face
 - Sanity
 - Square
+- Stormkit
 - [Your company](https://github.com/vitejs/companies-using-vite/edit/main/README.md)
 
 ## Frameworks and tools that depend on Vite
@@ -47,3 +48,5 @@ Add yours via a pull request!
 - [Waku](https://waku.gg/)
 - [Ember](https://emberjs.com/)
 - [Playwright](https://playwright.dev/)
+- [Stormkit Monorepo React](https://github.com/stormkit-io/monorepo-template-react)
+

--- a/README.md
+++ b/README.md
@@ -48,5 +48,4 @@ Add yours via a pull request!
 - [Waku](https://waku.gg/)
 - [Ember](https://emberjs.com/)
 - [Playwright](https://playwright.dev/)
-- [Stormkit Monorepo React](https://github.com/stormkit-io/monorepo-template-react)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Add yours via a pull request!
 - NASA (Vue / Nuxt)
 - Shopify (React + Vite)
 - Cloudflare (Astro, Qwik)
-- 
 - GitLab (Vue)
 - Porsche (Astro)
 - The Guardian (Astro)


### PR DESCRIPTION
Adds [stormkit.io](https://www.stormkit.io) as a company that uses Vite and the React monorepo template that depends on Vite: https://github.com/stormkit-io/monorepo-template-react