### PR TITLE
Add Strapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Add yours via a pull request!
 - Hugging Face
 - Sanity
 - Square
+- Strapi
 - [Your company](https://github.com/vitejs/companies-using-vite/edit/main/README.md)
 
 ## Frameworks and tools that depend on Vite
@@ -47,3 +48,4 @@ Add yours via a pull request!
 - [Waku](https://waku.gg/)
 - [Ember](https://emberjs.com/)
 - [Playwright](https://playwright.dev/)
+- [Strapi](https://strapi.io/)


### PR DESCRIPTION
Adding [Strapi](https://strapi.io/), the open-source Headless CMS.

We recently added Vite to the project (https://strapi.io/five).