### PR TITLE
Add Jozu

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Add yours via a pull request!
 - Der Standard (Svelte / SvelteKit)
 - Alibaba (Vue)
 - Sequel.io (React + Vite)
+- [Jozu](https://jozu.ml)
 - [Your company](https://github.com/vitejs/companies-using-vite/edit/main/README.md)
 
 ## Frameworks and tools that depend on Vite

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Add yours via a pull request!
 - Der Standard (Svelte / SvelteKit)
 - Alibaba (Vue)
 - Sequel.io (React + Vite)
-- [Jozu](https://jozu.ml)
+- Jozu
 - [Your company](https://github.com/vitejs/companies-using-vite/edit/main/README.md)
 
 ## Frameworks and tools that depend on Vite


### PR DESCRIPTION
The safest way to get your AI projects from dev to prod.

Jozu Hub is a ModelKit Registry that makes it easy for teams of all skill levels to develop and manage models, datasets, codebases, and parameters.