### PR TITLE
add coditive to companies that use vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Add yours via a pull request!
 - Pineify (React + Vite)
 - Fundrise (Vue + Vite + Vitest)
 - IU Group (Vue / Nuxt / Vitest)
+- Coditive (WordPress / Vue / Nuxt)
 - [Your company](https://github.com/vitejs/companies-using-vite/edit/main/README.md)
 
 ## Frameworks and tools that depend on Vite


### PR DESCRIPTION
At [@coditive](https://x.com/coditive), Vite is essential for all projects, and its benefits have led us to integrate it into... the WordPress ecosystem as well 🔥 Our [setup guide](https://pragmate.dev/wordpress/vite/integration/) quickly became one of the top resources on the subject, so we'd be honored to be listed there 🤘