### PR TITLE
docs: add the list of companies using Vue/Nuxt

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Add yours via a pull request!
 ## Frameworks and tools that depend on Vite
 
 - [Vue / Nuxt](https://nuxt.com/)
+  - [Companies using Vue / Nuxt](https://github.com/cloydlau/companies-using-vue)
 - [Vitest](https://vitest.dev/)
 - [VitePress](https://vitepress.dev/)
 - [Laravel](https://laravel.com/docs/vite)


### PR DESCRIPTION
Hello Evan @yyx990803 ,

The mentioned list of companies using Vue/Nuxt (which depends on Vite) is quite incomplete. I have conducted a relatively comprehensive collection and analysis of well-known large companies using Vue/Nuxt. To my surprise, the adoption rate of Vue/Nuxt is much higher than I imagined. In fact, many companies or institutions like MIT, Lotus, Mercedes-Benz, BMW, Gucci, Prada, Game Science, Blizzard, and AMD are using Vue/Nuxt. For more details, please see: https://github.com/cloydlau/companies-using-vue.